### PR TITLE
Fix Wayland/KDE6 isolation

### DIFF
--- a/mega_instances.sh
+++ b/mega_instances.sh
@@ -6,7 +6,7 @@ MEGADIR="MEGA"
 FILEPATH=$REALHOME/.config/megasync-instances
 FILE=$FILEPATH/status
 ERR=0
-VERSION="0.0.1"
+VERSION="0.0.2"
 echo "REALHOME = $REALHOME"
 
 zenity () {
@@ -24,45 +24,52 @@ checkDep () {
 #Function that creates a Desktop Entry and sets it up for autostart at the login
 generateDesktopEntry () {
   DEPATH=$REALHOME/.config/autostart/mega_instances.desktop
-	mkdir -p /home/$USER/.config/autostart
-	echo "[Desktop Entry]" > $DEPATH
-	echo "Type=Application" >> $DEPATH
-	echo "Exec=/usr/bin/megasync-instances" >> $DEPATH
-	echo "Name=megasync_instances" >> $DEPATH
-	echo "Comment=Open all your MEGA instances"  >> $DEPATH
-	chmod +x $DEPATH
+    mkdir -p $REALHOME/.config/autostart
+    echo "[Desktop Entry]" > $DEPATH
+    echo "Type=Application" >> $DEPATH
+    echo "Exec=/usr/bin/megasync-instances" >> $DEPATH
+    echo "Name=megasync_instances" >> $DEPATH
+    echo "Comment=Open all your MEGA instances"  >> $DEPATH
+    chmod +x $DEPATH
 }
 
 finstall () {
   checkDep "zenity"
   checkDep "megasync"
 
-	if [[ $ERR -ne 0 ]]; then
-		>&2 echo "Error: Install all required dependencies before running MEGA-Instances"
-		exit 1
-	fi
+    if [[ $ERR -ne 0 ]]; then
+        >&2 echo "Error: Install all required dependencies before running MEGA-Instances"
+        exit 1
+    fi
 
-	frun
+    frun
 }
 
 frun () {
-	if [ $(cat $FILE) == "1" ];
-	then
-		echo "MEGA-Instances is already configured, launching the instances..."
+    if [ $(cat $FILE) == "1" ];
+    then
+        echo "MEGA-Instances is already configured, launching the instances..."
     echo "If you wish to run the first configuration again, manually remove $FILE"
 
     killall megasync 2> /dev/null #Close open megasync instances
 
-		for d in $REALHOME/$MEGADIR/*/ ; do
-			echo "Launching $d"
-			HOME=$d
-			megasync 2> /dev/null &
-		done
+        for d in $REALHOME/$MEGADIR/*/ ; do
+            # Remove trailing slash for the path
+            CURRENT_INSTANCE="${d%/}"
+            echo "Launching instance at $CURRENT_INSTANCE"
+            
+            # Application Isolation for Wayland/KDE6
+            HOME="$CURRENT_INSTANCE" \
+            XDG_CONFIG_HOME="$CURRENT_INSTANCE/.config" \
+            XDG_DATA_HOME="$CURRENT_INSTANCE/.local/share" \
+            QT_QPA_PLATFORM=xcb \
+            megasync 2> /dev/null &
+        done
 
-	else
-	  	echo "MEGA-Instances is not configured. Will now start the configuration."
+    else
+          echo "MEGA-Instances is not configured. Will now start the configuration."
 
-      if zenity --question --text=zenity --question --no-wrap --text="This is the first time you are running MEGA-Instances.\nIn order to continue we must delete your existing MEGA instance.\nPress Yes to continue, No to abort."; then
+      if zenity --question --no-wrap --text="This is the first time you are running MEGA-Instances.\nIn order to continue we must delete your existing MEGA instance.\nPress Yes to continue, No to abort."; then
           killall megasync 2> /dev/null #Close open megasync instances
           rm -rf ~/MEGA
           rm -f ~/.config/autostart/megasync.desktop
@@ -70,31 +77,38 @@ frun () {
           exit
       fi
 
-			INSTNUM=`zenity --entry --text="How many MEGA instances do you need?"`
-			mkdir -p $REALHOME/$MEGADIR
+            INSTNUM=`zenity --entry --text="How many MEGA instances do you need?"`
+            mkdir -p $REALHOME/$MEGADIR
 
-			for (( i=1; i<=INSTNUM; i++ ))
-			do
-				NAME=`zenity --entry --text="Insert the name for instance $i/$INSTNUM"`
-				ARRAY[$i]=$NAME
-				mkdir -p $REALHOME/$MEGADIR/$NAME
-			done
+            for (( i=1; i<=INSTNUM; i++ ))
+            do
+                NAME=`zenity --entry --text="Insert the name for instance $i/$INSTNUM"`
+                ARRAY[$i]=$NAME
+                mkdir -p $REALHOME/$MEGADIR/$NAME
+            done
 
-			for (( i=1; i<=INSTNUM; i++ ))
-			do
-				zenity --warning --text="Instance ${ARRAY[i]} ($i/$INSTNUM). Close it after the configuration."
-				HOME=$REALHOME/$MEGADIR/${ARRAY[$i]}
-				megasync
-			done
+            for (( i=1; i<=INSTNUM; i++ ))
+            do
+                zenity --warning --text="Instance ${ARRAY[i]} ($i/$INSTNUM). Close it after the configuration."
+                
+                CURRENT_INSTANCE="$REALHOME/$MEGADIR/${ARRAY[$i]}"
+                
+                # Configuration isolation
+                HOME="$CURRENT_INSTANCE" \
+                XDG_CONFIG_HOME="$CURRENT_INSTANCE/.config" \
+                XDG_DATA_HOME="$CURRENT_INSTANCE/.local/share" \
+                QT_QPA_PLATFORM=xcb \
+                megasync
+            done
 
-			generateDesktopEntry
+            generateDesktopEntry
 
-			zenity --warning --text="Will now launch all the instances. They will also start at every startup."
-			HOME=$REALHOME
-			echo 1 > $FILE #Mark as configured
-			bash $0 &
+            zenity --warning --text="Will now launch all the instances. They will also start at every startup."
+            HOME=$REALHOME
+            echo 1 > $FILE #Mark as configured
+            bash $0 &
       sleep 1
-	fi
+    fi
 }
 
 #Create config file if missing


### PR DESCRIPTION
Key Improvements Made:

    XDG Path Redirection: Added XDG_CONFIG_HOME and XDG_DATA_HOME. This prevents the "locked database" errors because each instance now looks for its config in ~/MEGA/InstanceName/.config instead of your real ~/.config.

    Platform Forcing: Added QT_QPA_PLATFORM=xcb. This tells the MEGA (Qt) app to use XWayland, which effectively disables the Wayland compositor's ability to "smartly" group these into a single process.

    Path Scrubbing: In the launch loop, I added ${d%/} to ensure the path doesn't end in a double slash, which can occasionally trip up certain file-watchers in Linux.

    Zenity Fix: I fixed a small typo in your original script where the first zenity call had the word zenity repeated inside the text string